### PR TITLE
fix: typo in --help (main.rs)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ fn main() -> Result<()>
         // Inform about the cache and log directory
         .after_help(format!(
             "This program caches RFCs to improve performance.\nThe cache is \
-             stored in the following directory: {}\n\nThe the log files are \
+             stored in the following directory: {}\n\nThe log files are \
              stored in: {}",
             cache.cache_dir().display(),
             get_log_files_dir_path().display()


### PR DESCRIPTION
Hi! Just a minor typo I found in help message.